### PR TITLE
Support 2D SVO texture layout

### DIFF
--- a/svo5.html
+++ b/svo5.html
@@ -137,7 +137,7 @@
                 try {
                     const {dense, size, palette} = await parseVOX(await f.arrayBuffer());
                     SVO.ensurePalette(SVO.makePaletteTexture(palette));
-                    SVO.uploadSVO(SVO.buildSVOFromDense(dense, size));
+                    SVO.uploadSVO(SVO.buildSVOFromDense(dense, size, renderer.capabilities.maxTextureSize));
                     stat.textContent = `Loaded ${f.name} : ${size}^3, nodes tex ${SVO.uSvoTex.image.width}x${SVO.uSvoTex.image.height}`;
                 } catch (err) {
                     console.error(err);


### PR DESCRIPTION
## Summary
- Limit SVO node texture width and compute height dynamically for 2D layout
- Reallocate GPU texture when either dimension changes during upload
- Forward renderer max texture size when building from VOX files

## Testing
- ⚠️ `node -e "import('./svo5.js').then(()=>console.log('ok')).catch(e=>console.error(e))"` *(missing `three` module)*

------
https://chatgpt.com/codex/tasks/task_e_689dcd26df4083219e83ea5fff9de120