### PR TITLE
Handle SVO texture size updates

### DIFF
--- a/svo5.js
+++ b/svo5.js
@@ -303,13 +303,18 @@ uvec4 fetchU32(uint idx){
 
 // ----- Upload helpers (AFTER material exists) -----
 export function uploadSVO({data, width, height, rootId, svoSize}) {
-    if (!uSvoTex || uSvoTex.image.width !== width) {
-        uSvoTex = new THREE.DataTexture(data,width,height,THREE.RGBAFormat,THREE.FloatType);
+    if (!uSvoTex ||
+        uSvoTex.image.width !== width ||
+        uSvoTex.image.height !== height) {
+        uSvoTex = new THREE.DataTexture(data, width, height, THREE.RGBAFormat, THREE.FloatType);
         uSvoTex.magFilter = uSvoTex.minFilter = THREE.NearestFilter;
         uSvoTex.wrapS = uSvoTex.wrapT = THREE.ClampToEdgeWrapping;
         uSvoTex.needsUpdate = true;
         mat.uniforms.uSvoTex.value = uSvoTex;
     } else {
+        if (uSvoTex.image.data.length !== width * height * 4) {
+            uSvoTex.image.data = new Float32Array(width * height * 4);
+        }
         uSvoTex.image.data.set(data);
         uSvoTex.needsUpdate = true;
     }


### PR DESCRIPTION
## Summary
- Reinitialize SVO texture when width or height changes
- Allocate texture data array when size changes to match width*height*4

## Testing
- `node -e "import('./svo5.js')"` *(fails: THREE.Vector2 is not a constructor)*

------
https://chatgpt.com/codex/tasks/task_e_689dcd2abfc48321b9110ba62344c094